### PR TITLE
Use test-unit gem explicitly

### DIFF
--- a/fluent-plugin-pgjson.gemspec
+++ b/fluent-plugin-pgjson.gemspec
@@ -18,4 +18,5 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency "fluentd"
   s.add_runtime_dependency "pg"
+  s.add_development_dependency "test-unit", ">= 3.1.0"
 end


### PR DESCRIPTION
Because Ruby 2.2 does not provide minitest with test-unit compatible
layer.