### PR TITLE
Support secret parameters feature

### DIFF
--- a/lib/fluent/plugin/out_pgjson.rb
+++ b/lib/fluent/plugin/out_pgjson.rb
@@ -9,7 +9,7 @@ class PgJsonOutput < Fluent::BufferedOutput
   config_param :database   , :string
   config_param :table      , :string
   config_param :user       , :string  , :default => nil
-  config_param :password   , :string  , :default => nil
+  config_param :password   , :string  , :default => nil , :secret => true
   config_param :time_col   , :string  , :default => 'time'
   config_param :tag_col    , :string  , :default => 'tag'
   config_param :record_col , :string  , :default => 'record'


### PR DESCRIPTION
Fluentd 0.12.13 or later supports secret parameters feature.
This feature works as below:


```log
  <match **>
    type pgjson
    host localhost
    port 5432
    sslmode require
    database fluentd
    table fluentd
    user postgres
    password xxxxxx
    time_col time
    tag_col tag
    record_col record
  </match>
</ROOT>
```

If you use older fluentd, `:secret => true` in config_param will be simply ignored.