### PR TITLE
Migrate to use v0.14 API and some tweaks

### DIFF
--- a/fluent-plugin-pgjson.gemspec
+++ b/fluent-plugin-pgjson.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "fluentd"
   s.add_runtime_dependency "pg"
   s.add_development_dependency "test-unit", ">= 3.1.0"
+  s.add_development_dependency "rake", ">= 11.0"
 end

--- a/lib/fluent/plugin/out_pgjson.rb
+++ b/lib/fluent/plugin/out_pgjson.rb
@@ -1,7 +1,14 @@
-module Fluent
+require 'fluent/plugin/output'
+require 'pg'
 
-class PgJsonOutput < Fluent::BufferedOutput
+module Fluent::Plugin
+
+class PgJsonOutput < Fluent::Output
   Fluent::Plugin.register_output('pgjson', self)
+
+  helpers :compat_parameters
+
+  DEFAULT_BUFFER_TYPE = "memory"
 
   config_param :host       , :string  , :default => 'localhost'
   config_param :port       , :integer , :default => 5432
@@ -14,14 +21,18 @@ class PgJsonOutput < Fluent::BufferedOutput
   config_param :tag_col    , :string  , :default => 'tag'
   config_param :record_col , :string  , :default => 'record'
   config_param :msgpack    , :bool    , :default => false
+  config_section :buffer do
+    config_set_default :@type, DEFAULT_BUFFER_TYPE
+    config_set_default :chunk_keys, ['tag']
+  end
 
   def initialize
     super
-    require 'pg'
     @conn = nil
   end
 
   def configure(conf)
+    compat_parameters_convert(conf, :buffer)
     super
   end
 
@@ -33,15 +44,20 @@ class PgJsonOutput < Fluent::BufferedOutput
     end
   end
 
+  def formatted_to_msgpack_binary
+    true
+  end
+
   def format(tag, time, record)
-    [tag, time, record].to_msgpack
+    [time, record].to_msgpack
   end
 
   def write(chunk)
     init_connection
     @conn.exec("COPY #{@table} (#{@tag_col}, #{@time_col}, #{@record_col}) FROM STDIN WITH DELIMITER E'\\x01'")
     begin
-      chunk.msgpack_each do |tag, time, record|
+      tag = chunk.metadata.tag
+      chunk.msgpack_each do |time, record|
         @conn.put_copy_data "#{tag}\x01#{Time.at(time).to_s}\x01#{record_value(record)}\n"
       end
     rescue => err

--- a/lib/fluent/plugin/out_pgjson.rb
+++ b/lib/fluent/plugin/out_pgjson.rb
@@ -34,6 +34,9 @@ class PgJsonOutput < Fluent::Output
   def configure(conf)
     compat_parameters_convert(conf, :buffer)
     super
+    unless @chunk_key_tag
+      raise Fluent::ConfigError, "'tag' in chunk_keys is required."
+    end
   end
 
   def shutdown

--- a/lib/fluent/plugin/out_pgjson.rb
+++ b/lib/fluent/plugin/out_pgjson.rb
@@ -40,11 +40,11 @@ class PgJsonOutput < Fluent::Output
   end
 
   def shutdown
-    super
-
     if ! @conn.nil? and ! @conn.finished?
       @conn.close()
     end
+
+    super
   end
 
   def formatted_to_msgpack_binary

--- a/test/plugin/test_out.rb
+++ b/test/plugin/test_out.rb
@@ -53,6 +53,28 @@ class PgJsonOutputTest < Test::Unit::TestCase
     assert_equal RECORD_COL, d.instance.record_col
   end
 
+  def test_invalid_chunk_keys
+    assert_raise_message(/'tag' in chunk_keys is required./) do
+      create_driver(Fluent::Config::Element.new(
+                      'ROOT', '', {
+                        '@type' => 'pgjson',
+                        'host' => "#{HOST}",
+                        'port' => "#{PORT}",
+                        'database' => "#{DATABASE}",
+                        'table' => "#{TABLE}",
+                        'user' => "#{USER}",
+                        'password' => "#{PASSWORD}",
+                        'time_col' => "#{TIME_COL}",
+                        'tag_col' => "#{TAG_COL}",
+                        'record_col' => "#{RECORD_COL}",
+                      }, [
+                        Fluent::Config::Element.new('buffer', 'mykey', {
+                                                      'chunk_keys' => 'mykey'
+                                                    }, [])
+                      ]))
+    end
+  end
+
   def test_write
     with_connection do |conn|
       tag = 'test'

--- a/test/plugin/test_out.rb
+++ b/test/plugin/test_out.rb
@@ -7,8 +7,8 @@ class PgJsonOutputTest < Test::Unit::TestCase
   PORT = 5432
   DATABASE = "postgres"
   TABLE = "test_fluentd_#{SecureRandom.hex}"
-  USER = "postgres"
-  PASSWORD = "postgres"
+  USER = ENV["PSQL_USER"] || "postgres"
+  PASSWORD = ENV["PSQL_PASSWORD"] || "postgres"
 
   TIME_COL = "time"
   TAG_COL = "tag"


### PR DESCRIPTION
Hi, I've tried to migrate to use v0.14 API in this plugin.
And I also tweaked gem dependency and preparing test cases.

Because homebrewed PostgreSQL does not use postgres user.
Instead, it uses actual administrator user who can execute sudo.

We can run testcases with homebrewed PostgreSQL on macOS like as:

```
$ PSQL_USER=$USER PSQL_PASSWORD= bundle exec rake test
```