### PR TITLE
Use PG::Connection instead of PGconn

### DIFF
--- a/test/plugin/test_out.rb
+++ b/test/plugin/test_out.rb
@@ -139,7 +139,7 @@ class PgJsonOutputTest < Test::Unit::TestCase
     conn = nil
 
     assert_nothing_raised do
-      conn = PGconn.new(:dbname => DATABASE, :host => HOST, :port => PORT, :user => USER, :password => PASSWORD)
+      conn = PG::Connection.new(:dbname => DATABASE, :host => HOST, :port => PORT, :user => USER, :password => PASSWORD)
     end
 
     conn


### PR DESCRIPTION
Because PGconn has been removed since pg gem v1.0.0.