### PR TITLE
Replace yajl-ruby with the json gem for JSON handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ CREATE TABLE fluentd (
 |tag_col|The column name for the tag|`tag`|
 |record_col|The column name for the record|`record`|
 |msgpack|If true, insert records formatted as msgpack|`false`|
-|encoder|JSON encoder (`yajl`, `json`)|`json`|
+|encoder|JSON encoder (`yajl`, `json`) Starting from v1.0.3, `yajl` is no longer available and internally defaults to `json`|`json`|
 
 ## Copyright
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ CREATE TABLE fluentd (
   #tag_col tag
   #record_col record
   #msgpack false
-  #encoder yajl
+  #encoder json
 </match>
 ```
 
@@ -87,7 +87,7 @@ CREATE TABLE fluentd (
 |tag_col|The column name for the tag|`tag`|
 |record_col|The column name for the record|`record`|
 |msgpack|If true, insert records formatted as msgpack|`false`|
-|encoder|JSON encoder (`yajl`, `json`)|`yajl`|
+|encoder|JSON encoder (`yajl`, `json`)|`json`|
 
 ## Copyright
 

--- a/lib/fluent/plugin/out_pgjson.rb
+++ b/lib/fluent/plugin/out_pgjson.rb
@@ -1,6 +1,5 @@
 require "fluent/plugin/output"
 require "pg"
-require "yajl"
 require "json"
 
 module Fluent::Plugin
@@ -34,7 +33,7 @@ module Fluent::Plugin
     desc "If true, insert records formatted as msgpack"
     config_param :msgpack, :bool, default: false
     desc "JSON encoder (yajl/json)"
-    config_param :encoder, :enum, list: [:yajl, :json], default: :yajl
+    config_param :encoder, :enum, list: [:yajl, :json], default: :json # NOTE: Contains yajl for backward compatibility
 
     config_param :time_format, :string, default: "%F %T.%N %z"
 
@@ -56,7 +55,8 @@ module Fluent::Plugin
       end
       @encoder = case @encoder
                  when :yajl
-                   Yajl
+                   log.info "encoder 'yajl' is deprecated. Please use 'json' instead."
+                   JSON
                  when :json
                    JSON
                  end

--- a/test/plugin/test_out.rb
+++ b/test/plugin/test_out.rb
@@ -17,7 +17,7 @@ class PgJsonOutputTest < Test::Unit::TestCase
   TIME_COL = "time"
   TAG_COL = "tag"
   RECORD_COL = "record"
-  ENCODER = Yajl
+  ENCODER = JSON
 
   CONFIG = %[
     @type pgjson


### PR DESCRIPTION
Since the yajl-ruby gem depends on a deprecated Ruby C API, it cannot be installed with Ruby 4.1.